### PR TITLE
Localization issue solved

### DIFF
--- a/pdf2keynote/applescripts/create_keynote_document.scpt
+++ b/pdf2keynote/applescripts/create_keynote_document.scpt
@@ -5,6 +5,6 @@ on run argv
         activate
         set thisDocument to ¬
             make new document with properties ¬
-                {document theme:theme "White", width:w, height:h}
+                {document theme:theme id "Application/White/Standard", width:w, height:h}
     end tell
 end run


### PR DESCRIPTION
This script does not work with localized versions of keynote since the "theme names" are localized as well. Using the unique "theme id" does work on all localizations.